### PR TITLE
Fix blog post flow: handle null user, ensure blogId, and improve navi…

### DIFF
--- a/app/src/main/java/org/openlake/sampoorna/presentation/features/blogs/BlogAdapter.kt
+++ b/app/src/main/java/org/openlake/sampoorna/presentation/features/blogs/BlogAdapter.kt
@@ -1,5 +1,6 @@
 package org.openlake.sampoorna.presentation.features.blogs
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
@@ -32,6 +33,7 @@ class BlogAdapter(val context: Context, private val blogViewModel: BlogViewModel
         return BlogViewHolder(view)
     }
 
+    @SuppressLint("SetTextI18n")
     override fun onBindViewHolder(holder: BlogViewHolder, position: Int) {
         val blog = blogList[position]
 
@@ -45,13 +47,17 @@ class BlogAdapter(val context: Context, private val blogViewModel: BlogViewModel
         holder.blogAuthor.text = "By ${if(blog.anonymous) "Anonymous" else blog.authorUsername}"
 
         if(!blog.anonymous) {
-            blogViewModel.getUser(blog.authorUid).observe(viewLifecycleOwner) {
-                Glide.with(context)
-                    .load(it.photoUrl)
-                    .placeholder(R.drawable.womenlogo)
-                    .centerCrop()
-                    .into(holder.blogAuthorImage)
+            //added  null check to avoid crashes
+            blogViewModel.getUser(blog.authorUid).observe(viewLifecycleOwner) { user ->
+                user?.let {
+                    Glide.with(context)
+                        .load(it.photoUrl ?: "")
+                        .placeholder(R.drawable.womenlogo)
+                        .centerCrop()
+                        .into(holder.blogAuthorImage)
+                }
             }
+
         }
 
         val blogDate = Date(blog.timestamp)


### PR DESCRIPTION
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ✅ My code follows the code style of this project.
- [ ] 📝 My change requires a change to the documentation.
- [ ] 🎀 I have updated the documentation accordingly.
- [x] 👀 I have read the [**CONTRIBUTING**](https://github.com/OpenLake/Sampoorna/blob/main/CONTRIBUTING.md) document.
- [x] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## 🔧 Pull Request Summary

This pull request addresses multiple issues and enhancements related to the blog feature, ensuring improved reliability and user experience during blog creation and display.

---

### ✅ Fixes and Improvements:

1. **🔁 `addBlog` now returns a `Boolean` instead of a `Task`**
   - Updated `BlogViewModel`:
     ```kotlin
     suspend fun addBlog(blog: Blog): Boolean
     ```
   - Uses `try-catch` and `kotlinx.coroutines.tasks.await()` to handle Firestore operations more reliably.
   - Allows easier coroutine-based handling in the UI layer.

2. **🖼️ Fixed crash in `BlogAdapter` due to null `User` or `photoUrl`**
   - Added null checks before loading user profile image with Glide:
     ```kotlin
     user?.let {
         Glide.with(context)
             .load(it.photoUrl ?: "")
             .placeholder(R.drawable.womenlogo)
             .centerCrop()
             .into(holder.blogAuthorImage)
     }
     ```

3. **🆔 Fixed blog ID being set to empty**
   - `UUID` is now generated and set before saving the blog to Firestore, ensuring consistency:
     ```kotlin
     val blogId = UUID.randomUUID().toString()
     val blogWithId = blog.copy(blogId = blogId)
     ```

4. **📤 Fixed screen not navigating back after creating a blog post**
   - Updated `CreateBlogFragment` to use `viewLifecycleOwner.lifecycleScope` and suspend function:
     - Shows feedback using `Toast` and delays navigation to ensure user sees confirmation.
     - Navigation only occurs after the blog post is successfully saved and UI feedback is shown.
     ```kotlin
     if (success) {
         Toast.makeText(requireActivity(), "Blog posted successfully!", Toast.LENGTH_LONG).show()
         delay(1000)
         findNavController().popBackStack()
     }
     ```

5. **📋 Added logging and error handling**
   - Multiple `Log.d()` and `Log.e()` statements added for better debugging of blog posting flow.
   - Safeguards like `isAdded` check prevent crashes due to fragment detachment.

---

### 🧪 Testing Done

- Tested blog posting with:
  - Required and optional fields
  - Anonymous switch
  - Repeated submissions
- Verified that:
  - App no longer crashes on missing user image
  - Blogs post correctly with valid `blogId`
  - Feedback is shown to the user and screen navigates back

---
